### PR TITLE
Wrong parameter in A/M Distribution

### DIFF
--- a/breakup.py
+++ b/breakup.py
@@ -58,7 +58,7 @@ def _Am(d):
         sigma2 = 0.3
 
     N1 = np.random.normal(mu1, sigma1, size=(1,1))
-    N2 = np.random.normal(mu2, sigma1, size=(1,1))
+    N2 = np.random.normal(mu2, sigma2, size=(1,1))
     return float(10. ** (alpha * N1 + (1-alpha) * N2))
 
 


### PR DESCRIPTION
As part of my Bachelors' Thesis, I am implementing the NASA Breakup Model in C++ under guidance of Pablo Gómez (@gomezzz) from ESA and Fabio Gratl (@FG-TUM). This Python implementation therefore was my reference implementation for the Breakup Model.

In order to validate the correctness of the data produced by my C++ implementation, I compared its output with the Python Implementation. In general, the data was similar expect for the A/M Distribution.

After several checks if found a little fault in the Python implementation. In Code Line 61 in Breakup.py is sigma1 reused in the second normal distribution although it should be sigma2.

Wrong version:
```python

    N1 = np.random.normal(mu1, sigma1, size=(1,1))
    N2 = np.random.normal(mu2, sigma1, size=(1,1))

```
Fixed version:
```python

    N1 = np.random.normal(mu1, sigma1, size=(1,1))
    N2 = np.random.normal(mu2, sigma2, size=(1,1)) #Fixed to sigma2

```

I added some diagrams which show the difference. The diagrams origin is a collision with resulting 4064 fragments:

A/M Distribution difference between fixed and non-fixed version:
![AM_Comparision](https://user-images.githubusercontent.com/52069730/124131120-c6721880-da7f-11eb-9c3b-b8745a187a0d.png)

L_c to A/M Distribution for fragments for the fixed version:
![LC_AM_wrongPython](https://user-images.githubusercontent.com/52069730/124131126-c70aaf00-da7f-11eb-9912-20e634cd5699.png)

L_c to A/M Distribution for fragments for the non-fixed version:
![LC_AM_correctedPython](https://user-images.githubusercontent.com/52069730/124131124-c70aaf00-da7f-11eb-9bc2-6e5d46af98b4.png)

Sources:
Johnson, Nicholas L., et al. “NASA’s new breakup model of EVOLVE 4.0” Advances in Space Research 28.9 (2001): 1377-1384